### PR TITLE
Fixes #17 - Session killed

### DIFF
--- a/area.js
+++ b/area.js
@@ -887,7 +887,7 @@ export const DrawingArea = GObject.registerClass({
         else if (this.currentElement && this.currentElement.shape == Shape.TEXT && this.isWriting)
             this.setPointerCursor('IBEAM');
         else if (!this.currentElement)
-            this.setPointerCursor(this.currentTool == Shape.NONE ? 'POINTING_HAND' : 'CROSSHAIR');
+            this.setPointerCursor(this.currentTool == Shape.NONE ? 'POINTER' : 'CROSSHAIR');
         else if (this.currentElement.shape != Shape.NONE && controlPressed)
             this.setPointerCursor('MOVE_OR_RESIZE_WINDOW');
     }


### PR DESCRIPTION
It appears that the cursor name `POINTING_HAND` was changed to `POINTER` in Gnome 48, this updates the name and avoids the session crashing.