### PR TITLE
E.G.O: Remove Gtk/Gdk imports from shell process

### DIFF
--- a/area.js
+++ b/area.js
@@ -51,7 +51,7 @@ import * as Elements from './elements.js'
 import { Image } from './files.js'
 import * as Menu from './menu.js'
 
-import Gtk from 'gi://Gtk?version=4.0';
+import Meta from 'gi://Meta';
 
 const MOTION_TIME = 1; // ms, time accuracy for free drawing, max is about 33 ms. The lower it is, the smoother the drawing is.
 const TEXT_CURSOR_TIME = 600; // ms
@@ -497,7 +497,7 @@ export const DrawingArea = GObject.registerClass({
             if (this.currentElement.points.length == 2)
                 // Translators: %s is a key label
                 this.emit('show-osd', this._extension.FILES.ICONS.ARC, _("Press <i>%s</i> to get\na fourth control point")
-                    .format(Gtk.accelerator_get_label(Clutter.KEY_Return, 0)), "", -1, true);
+                    .format(Meta.accelerator_name(0, Clutter.KEY_Return)), "", -1, true);
             this.currentElement.addPoint();
             this.updatePointerCursor(true);
             this._redisplay();
@@ -725,7 +725,7 @@ export const DrawingArea = GObject.registerClass({
             let icon = this._extension.FILES.ICONS[this.currentTool == Shape.POLYGON ? 'TOOL_POLYGON' : 'TOOL_POLYLINE'];
             // Translators: %s is a key label
             this.emit('show-osd', icon, _("Press <i>%s</i> to mark vertices")
-                .format(Gtk.accelerator_get_label(Clutter.KEY_Return, 0)), "", -1, true);
+                .format(Meta.accelerator_name(0, Clutter.KEY_Return)), "", -1, true);
         }
         // Wayland supports two cursors so its important to disconnect motionhandler to avoid broken two cursors drawing
         if (this.motionHandler) {
@@ -803,7 +803,7 @@ export const DrawingArea = GObject.registerClass({
         this.currentElement.cursorPosition = 0;
         // Translators: %s is a key label
         this.emit('show-osd', this._extension.FILES.ICONS.TOOL_TEXT, _("Press <i>%s</i>\nto start a new line")
-            .format(Gtk.accelerator_get_label(Clutter.KEY_Return, 0)), "", -1, true);
+            .format(Meta.accelerator_name(0, Clutter.KEY_Return)), "", -1, true);
         this._updateTextCursorTimeout();
         this.textHasCursor = true;
         this._redisplay();
@@ -879,7 +879,7 @@ export const DrawingArea = GObject.registerClass({
         }
     }
 
-    //Modifying MOVE_OR_RESIZE_WINDOW, to MOVE, both now function. //check in future versions of GNOME. 
+    //Modifying MOVE_OR_RESIZE_WINDOW, to MOVE, both now function. //check in future versions of GNOME.
     updatePointerCursor(controlPressed) {
         if (this.currentTool == Manipulation.MIRROR && this.grabbedElementLocked)
             this.setPointerCursor('CROSSHAIR');
@@ -1289,7 +1289,7 @@ export const DrawingArea = GObject.registerClass({
     _onDestroy() {
         this.textCursorTimeoutId = null; // To avoid calling _stopTextCursorTimeout.
         this._stopAll(true);
-        
+
         this._extension.drawingSettings.disconnect(this.drawingSettingsChangedHandler);
         this.erase();
         if (this._menu)

--- a/files.js
+++ b/files.js
@@ -450,7 +450,12 @@ export const Image = GObject.registerClass({
     setCairoSource(cr, x, y, width, height, preserveAspectRatio, color) {
         let pixbuf = preserveAspectRatio ? this.getPixbufAtScale(width, height, color)
             : this.getPixbuf(color).scale_simple(width, height, GdkPixbuf.InterpType.BILINEAR);
-        Gdk.cairo_set_source_pixbuf(cr, pixbuf, x, y);
+        // Use GdkPixbuf's cairo integration
+        cr.save();
+        cr.translate(x, y);
+        cr.scale(width / pixbuf.get_width(), height / pixbuf.get_height());
+        cr.setSourceSurface(pixbuf, 0, 0);
+        cr.restore();
     }
 
     _replaceColor(contents, color) {

--- a/helper.js
+++ b/helper.js
@@ -34,7 +34,7 @@ import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.j
 
 import { CURATED_UUID as UUID } from './utils.js';
 
-import Meta from 'gi://Meta';
+import GLib from 'gi://GLib';
 
 const GS_VERSION = Config.PACKAGE_VERSION;
 const Tweener = GS_VERSION < '3.33.0' ? imports.ui.tweener : null;
@@ -88,7 +88,7 @@ export const DrawingHelper = GObject.registerClass({
         if (!this._helpKeyLabel)
             this._updateHelpKeyLabel();
 
-        return this._helpKeyLabel;
+        return GLib.markup_escape_text(this._helpKeyLabel, -1);
     }
 
     _populate() {
@@ -103,9 +103,12 @@ export const DrawingHelper = GObject.registerClass({
                 return;
 
             let hbox = new St.BoxLayout({ vertical: false });
-            let shortcut = this._extension.settings.get_strv(settingKeys)[0] || _("Not set");
+            let shortcut = this._extension.settings.get_strv(settingKeys)[0];
+            shortcut = GLib.markup_escape_text(shortcut, -1);
             hbox.add_child(new St.Label({ text: this._extension.settings.settings_schema.get_key(settingKeys).get_summary() }));
-            hbox.add_child(new St.Label({ text: shortcut, x_expand: true }));
+            let label = new St.Label({ text: "<b><i>" + shortcut + "</i></b>", x_expand: true })
+            label.get_clutter_text().set_use_markup(true);
+            hbox.add_child(label);
             this.vbox.add_child(hbox);
         });
 
@@ -120,8 +123,9 @@ export const DrawingHelper = GObject.registerClass({
         //         let [action, shortcut] = pair;
         //         let hbox = new St.BoxLayout({ vertical: false });
         //         hbox.add_child(new St.Label({ text: action }));
-        //         hbox.add_child(new St.Label({ text: shortcut, x_expand: true }));
-        //         hbox.get_children()[0].get_clutter_text().set_use_markup(true);
+        //         hbox.add_child(new St.Label({ text: shortcut, x_expand: true }).get_clutter_text().set_use_markup(true));
+
+        //         hbox.get_children()[0]);
         //         this.vbox.add_child(hbox);
         //     });
         // });
@@ -135,9 +139,12 @@ export const DrawingHelper = GObject.registerClass({
                 return;
 
             let hbox = new St.BoxLayout({ vertical: false });
-            let shortcut = this._extension.internalShortcutSettings.get_strv(settingKeys)[0] || _("Not set");
+            let shortcut = this._extension.internalShortcutSettings.get_strv(settingKeys)[0];
+            shortcut = GLib.markup_escape_text(shortcut, -1);
             hbox.add_child(new St.Label({ text: this._extension.internalShortcutSettings.settings_schema.get_key(settingKeys).get_summary() }));
-            hbox.add_child(new St.Label({ text: shortcut, x_expand: true }));
+            let label = new St.Label({ text: "<b><i>" + shortcut + "</i></b>", x_expand: true })
+            label.get_clutter_text().set_use_markup(true);
+            hbox.add_child(label);
             this.vbox.add_child(hbox);
         });
 
@@ -151,11 +158,14 @@ export const DrawingHelper = GObject.registerClass({
             if (!mediaKeysSettings.settings_schema.has_key(settingKey))
                 continue;
             let shortcut = GS_VERSION < '3.33.0' ? mediaKeysSettings.get_string(settingKey) : mediaKeysSettings.get_strv(settingKey)[0];
+            shortcut = GLib.markup_escape_text(shortcut, -1);
             if (!shortcut)
                 continue;
             let hbox = new St.BoxLayout({ vertical: false });
             hbox.add_child(new St.Label({ text: mediaKeysSettings.settings_schema.get_key(settingKey).get_summary() }));
-            hbox.add_child(new St.Label({ text: shortcut, x_expand: true }));
+            let label = new St.Label({ text: "<b><i>" + shortcut + "</i></b>", x_expand: true })
+            label.get_clutter_text().set_use_markup(true);
+            hbox.add_child(label);
             this.vbox.add_child(hbox);
         }
     }

--- a/helper.js
+++ b/helper.js
@@ -34,7 +34,7 @@ import { gettext as _ } from 'resource:///org/gnome/shell/extensions/extension.j
 
 import { CURATED_UUID as UUID } from './utils.js';
 
-import Gtk from 'gi://Gtk?version=4.0';
+import Meta from 'gi://Meta';
 
 const GS_VERSION = Config.PACKAGE_VERSION;
 const Tweener = GS_VERSION < '3.33.0' ? imports.ui.tweener : null;
@@ -49,14 +49,14 @@ const MEDIA_KEYS_KEYS = ['screenshot', 'screenshot-clip', 'area-screenshot', 'ar
 export const DrawingHelper = GObject.registerClass({
     GTypeName: `${UUID}-DrawingHelper`,
 }, class DrawingHelper  extends St.ScrollView {
-    
+
     _init(extension, params, monitor) {
         params.style_class = 'osd-window draw-on-gnome-helper';
         super._init(params);
         this._extension = extension;
         this.monitor = monitor;
         this.hide();
-        
+
         this.settingsHandler = this._extension.settings.connect('changed', this._onSettingsChanged.bind(this));
         this.internalShortcutsettingsHandler = this._extension.internalShortcutSettings.connect('changed', this._onSettingsChanged.bind(this));
         this.connect('destroy', () => {
@@ -64,62 +64,58 @@ export const DrawingHelper = GObject.registerClass({
             this._extension.internalShortcutSettings.disconnect(this.internalShortcutsettingsHandler);
         });
     }
-    
+
     _onSettingsChanged(settings, key) {
         if (key == 'toggle-help')
             this._updateHelpKeyLabel();
-        
+
         if (this.vbox) {
             this.vbox.destroy();
             delete this.vbox;
         }
     }
-    
+
     _updateHelpKeyLabel() {
         try {
-            let [, keyval, mods] = Gtk.accelerator_parse(this._extension.internalShortcutSettings.get_strv('toggle-help')[0] || '');
-            this._helpKeyLabel = Gtk.accelerator_get_label(keyval, mods);
+            this._helpKeyLabel = this._extension.internalShortcutSettings.get_strv('toggle-help')[0];
         } catch(e) {
             logError(e);
             this._helpKeyLabel = " ";
         }
     }
-    
+
     get helpKeyLabel() {
         if (!this._helpKeyLabel)
             this._updateHelpKeyLabel();
-        
+
         return this._helpKeyLabel;
     }
-    
+
     _populate() {
         this.vbox = new St.BoxLayout({ vertical: true });
         this.add_child(this.vbox);
         this.vbox.add_child(new St.Label({ text: _("Global") }));
-        
+
         Shortcuts.GLOBAL_KEYBINDINGS.forEach((settingKeys) => {
-            //if (index)
             this.vbox.add_child(new St.BoxLayout({ vertical: false, style_class: 'draw-on-gnome-helper-separator' }));
-            
-            //settingKeys.forEach(settingKey => {
-                if (!this._extension.settings.get_strv(settingKeys)[0])
-                    return;
-                
-                let hbox = new St.BoxLayout({ vertical: false });
-                let [, keyval, mods] = Gtk.accelerator_parse(this._extension.settings.get_strv(settingKeys)[0] || '');
-                hbox.add_child(new St.Label({ text: this._extension.settings.settings_schema.get_key(settingKeys).get_summary() }));
-                hbox.add_child(new St.Label({ text: Gtk.accelerator_get_label(keyval, mods), x_expand: true }));
-                this.vbox.add_child(hbox);
-          //  });
+
+            if (!this._extension.settings.get_strv(settingKeys)[0])
+                return;
+
+            let hbox = new St.BoxLayout({ vertical: false });
+            let shortcut = this._extension.settings.get_strv(settingKeys)[0] || _("Not set");
+            hbox.add_child(new St.Label({ text: this._extension.settings.settings_schema.get_key(settingKeys).get_summary() }));
+            hbox.add_child(new St.Label({ text: shortcut, x_expand: true }));
+            this.vbox.add_child(hbox);
         });
-        
+
         this.vbox.add_child(new St.BoxLayout({ vertical: false, style_class: 'draw-on-gnome-helper-separator' }));
         this.vbox.add_child(new St.Label({ text: _("Internal") }));
-        
+
         // Shortcuts.OTHERS.forEach((pairs, index) => {
         //     if (index)
         //         this.vbox.add_child(new St.BoxLayout({ vertical: false, style_class: 'draw-on-gnome-helper-separator' }));
-            
+
         //     pairs.forEach(pair => {
         //         let [action, shortcut] = pair;
         //         let hbox = new St.BoxLayout({ vertical: false });
@@ -129,63 +125,59 @@ export const DrawingHelper = GObject.registerClass({
         //         this.vbox.add_child(hbox);
         //     });
         // });
-        
+
         // this.vbox.add_child(new St.BoxLayout({ vertical: false, style_class: 'draw-on-gnome-helper-separator' }));
-        
+
         Shortcuts.INTERNAL_KEYBINDINGS.forEach((settingKeys) => {
-            //if (index)
-              this.vbox.add_child(new St.BoxLayout({ vertical: false, style_class: 'draw-on-gnome-helper-separator' }));
-            
-            //settingKeys.forEach(settingKey => {
-                if (!this._extension.internalShortcutSettings.get_strv(settingKeys)[0])
-                    return;
-                
-                let hbox = new St.BoxLayout({ vertical: false });
-                let [, keyval, mods] = Gtk.accelerator_parse(this._extension.internalShortcutSettings.get_strv(settingKeys)[0] || '');
-                hbox.add_child(new St.Label({ text: this._extension.internalShortcutSettings.settings_schema.get_key(settingKeys).get_summary() }));
-                hbox.add_child(new St.Label({ text: Gtk.accelerator_get_label(keyval, mods), x_expand: true }));
-                this.vbox.add_child(hbox);
-            //});
+            this.vbox.add_child(new St.BoxLayout({ vertical: false, style_class: 'draw-on-gnome-helper-separator' }));
+
+            if (!this._extension.internalShortcutSettings.get_strv(settingKeys)[0])
+                return;
+
+            let hbox = new St.BoxLayout({ vertical: false });
+            let shortcut = this._extension.internalShortcutSettings.get_strv(settingKeys)[0] || _("Not set");
+            hbox.add_child(new St.Label({ text: this._extension.internalShortcutSettings.settings_schema.get_key(settingKeys).get_summary() }));
+            hbox.add_child(new St.Label({ text: shortcut, x_expand: true }));
+            this.vbox.add_child(hbox);
         });
-        
+
         let mediaKeysSettings;
         try { mediaKeysSettings = this._extension.getSettings(MEDIA_KEYS_SCHEMA); } catch(e) { return; }
-        
+
         this.vbox.add_child(new St.BoxLayout({ vertical: false, style_class: 'draw-on-gnome-helper-separator' }));
         this.vbox.add_child(new St.Label({ text: _("System") }));
-        
+
         for (let settingKey of MEDIA_KEYS_KEYS) {
             if (!mediaKeysSettings.settings_schema.has_key(settingKey))
                 continue;
             let shortcut = GS_VERSION < '3.33.0' ? mediaKeysSettings.get_string(settingKey) : mediaKeysSettings.get_strv(settingKey)[0];
             if (!shortcut)
                 continue;
-            let [, keyval, mods] = Gtk.accelerator_parse(shortcut || '');
             let hbox = new St.BoxLayout({ vertical: false });
             hbox.add_child(new St.Label({ text: mediaKeysSettings.settings_schema.get_key(settingKey).get_summary() }));
-            hbox.add_child(new St.Label({ text: Gtk.accelerator_get_label(keyval, mods), x_expand: true }));
+            hbox.add_child(new St.Label({ text: shortcut, x_expand: true }));
             this.vbox.add_child(hbox);
         }
     }
-    
+
     showHelp() {
         if (!this.vbox)
             this._populate();
-        
+
         this.opacity = 0;
         this.show();
-        
+
         let maxHeight = this.monitor.height * 3 / 4;
         this.set_height(Math.min(this.height, maxHeight));
         this.set_position(Math.floor(this.monitor.width / 2 - this.width / 2),
                           Math.floor(this.monitor.height / 2 - this.height / 2));
-                          
+
         // St.PolicyType: GS 3.32+
         if (this.height == maxHeight)
-            this.vscrollbar_policy = St.PolicyType ? St.PolicyType.ALWAYS : Gtk.PolicyType.ALWAYS;
+            this.vscrollbar_policy = St.PolicyType ? St.PolicyType.ALWAYS : 1;
         else
-            this.vscrollbar_policy = St.PolicyType ? St.PolicyType.NEVER : Gtk.PolicyType.NEVER;
-        
+            this.vscrollbar_policy = St.PolicyType ? St.PolicyType.NEVER : 0;
+
         if (Tweener) {
             Tweener.removeTweens(this);
             Tweener.addTween(this, { opacity: 255,
@@ -198,7 +190,7 @@ export const DrawingHelper = GObject.registerClass({
                         transition: Clutter.AnimationMode.EASE_OUT_QUAD });
         }
     }
-    
+
     hideHelp() {
         if (Tweener) {
             Tweener.removeTweens(this);


### PR DESCRIPTION
Fixes issue #16, part 3.

```
Gtk and Gdk cannot be imported to the GNOME Shell process.

line 54 area.js
line 37 helper.js
line 453 files.js
```

This was cherry-picked, so I'm not sure how stable this is in the `E.G.O.-ver-1` branch since it's a bit old, but it runs fine in Gnome 48 on the `main` branch. If it's better, I can also make a PR for my [recent changes](https://github.com/daveprowse/Draw-On-Gnome/compare/main...esauvisky:Draw-On-Gnome:main) that include this patch as well into 'main' here. Just let me know.