### PR TITLE
Prevent potential errors by verifying keyboardBox parent

### DIFF
--- a/areamanager.js
+++ b/areamanager.js
@@ -343,7 +343,7 @@ export class AreaManager {
         let activeIndex = this.areas.indexOf(this.activeArea);
         
         if (this.activeArea.get_parent() == Main.uiGroup) {
-            Main.uiGroup.set_child_at_index(Main.layoutManager.keyboardBox, this.oldKeyboardIndex);
+            if (Main.layoutManager.keyboardBox.get_parent() === Main.uiGroup) Main.uiGroup.set_child_at_index(Main.layoutManager.keyboardBox, this.oldKeyboardIndex);
             Main.uiGroup.remove_child(this.activeArea);
             Main.layoutManager._backgroundGroup.insert_child_above(this.activeArea, Main.layoutManager._bgManagers[activeIndex].backgroundActor);
             if (!this.onDesktop)
@@ -353,7 +353,7 @@ export class AreaManager {
             Main.uiGroup.add_child(this.activeArea);
             // move the keyboard above the area to make it available with text entries
             this.oldKeyboardIndex = Main.uiGroup.get_children().indexOf(Main.layoutManager.keyboardBox);
-            Main.uiGroup.set_child_above_sibling(Main.layoutManager.keyboardBox, this.activeArea);
+            if (Main.layoutManager.keyboardBox.get_parent() === Main.uiGroup) Main.uiGroup.set_child_above_sibling(Main.layoutManager.keyboardBox, this.activeArea);
         }
     }
     


### PR DESCRIPTION
Hi maintainers,

This fixes an issue where toggling the drawing area would fail if the on-screen keyboard (keyboardBox) was not a direct child of Main.uiGroup.

I added a check in areamanager.js to verify the keyboard's parent before attempting to reorder it.

Tested on GNOME 49, I apologize but I'm unable to test the fix on different versions.
It fixed local issues when no drawings were appearing on screen, hope the fix helps.