### PR TITLE
Fix drawing with touchpads and multi-device pointers

### DIFF
--- a/area.js
+++ b/area.js
@@ -671,6 +671,84 @@ export const DrawingArea = GObject.registerClass({
         return this.layerContainer.transform_stage_point(stageX, stageY);
     }
 
+    // Returns the physical device of an event, whatever the GNOME version.
+    _getEventDevice(event) {
+        try {
+            if (event.get_source_device) {
+                let device = event.get_source_device();
+                if (device)
+                    return device;
+            }
+        } catch (e) {}
+
+        try {
+            if (event.get_device)
+                return event.get_device();
+        } catch (e) {}
+
+        return null;
+    }
+
+    // True for every device that drives the ordinary pointer cursor.
+    // Unknown or unsupported enum values are treated as pointer-like, so a
+    // missing API can never break drawing on another GNOME version.
+    _isPointerLikeDevice(device) {
+        let types = Clutter.InputDeviceType;
+        if (!types)
+            return true;
+
+        let type;
+        try {
+            if (!device.get_device_type)
+                return true;
+            type = device.get_device_type();
+        } catch (e) {
+            return true;
+        }
+
+        // Devices owning a separate cursor are the only ones that must not be
+        // mixed with the pointer.
+        let ownCursor = [
+            types.TOUCHSCREEN_DEVICE,
+            types.PEN_DEVICE,
+            types.ERASER_DEVICE,
+            types.TABLET_DEVICE,
+        ];
+
+        return !ownCursor.some(t => t !== undefined && t === type);
+    }
+
+    // The previous test rejected motion as soon as the two device wrappers
+    // were not strictly identical. That breaks common hardware: on ThinkPads
+    // the physical buttons belong to the TrackPoint device while motion comes
+    // from the Synaptics touchpad, so press and motion never match and nothing
+    // is ever drawn.
+    //
+    // Several physical devices legitimately share a single pointer cursor and
+    // must all be accepted. Only devices owning a separate cursor (touchscreen,
+    // pen, tablet) are still filtered out, which is what the Wayland
+    // two-cursor guard was actually meant to do.
+    _isSameDevice(clickedDevice, event) {
+        if (!clickedDevice)
+            return true;
+
+        let device = this._getEventDevice(event);
+        if (!device || device === clickedDevice)
+            return true;
+
+        try {
+            if (device.get_device_name && clickedDevice.get_device_name &&
+                device.get_device_name() === clickedDevice.get_device_name())
+                return true;
+        } catch (e) {}
+
+        // Mouse, touchpad, trackpoint and trackball all move the same cursor.
+        if (this._isPointerLikeDevice(clickedDevice) && this._isPointerLikeDevice(device))
+            return true;
+
+        return false;
+    }
+
     _onButtonPressed(actor, event) {
         if (this.spaceKeyPressed)
             return Clutter.EVENT_PROPAGATE;
@@ -701,7 +779,7 @@ export const DrawingArea = GObject.registerClass({
                 if (this.grabbedElement)
                     this._startTransforming(x, y, controlPressed, shiftPressed);
             } else {
-                this._startDrawing(x, y, shiftPressed, (event.get_device ? event.get_device() : null) || event.get_source_device());
+                this._startDrawing(x, y, shiftPressed, this._getEventDevice(event));
             }
             return Clutter.EVENT_STOP;
             // End Laser Button Press Handling Code
@@ -1040,7 +1118,7 @@ export const DrawingArea = GObject.registerClass({
                 if (!s)
                     return;
                 
-                if (clickedDevice != (event.get_device ? event.get_device() : null) && clickedDevice != event.get_source_device())
+                if (!this._isSameDevice(clickedDevice, event))
                     return Clutter.EVENT_PROPAGATE;
 
                 if (this.spaceKeyPressed)
@@ -1144,9 +1222,9 @@ export const DrawingArea = GObject.registerClass({
                 return;
             
             // To avoid painting due to the wrong device (2 cursors wayland support)
-            //Modified for GNOME 46/47 support
-            if (clickedDevice != (event.get_device ? event.get_device() : null) && clickedDevice != event.get_source_device())
-                return Clutter.EVENT_PROPAGATE;            
+            // Modified for GNOME 46+ and for multi-device pointers.
+            if (!this._isSameDevice(clickedDevice, event))
+                return Clutter.EVENT_PROPAGATE;
 
             if (this.spaceKeyPressed)
                 return;


### PR DESCRIPTION
# PR 56 - Fix drawing with touchpads and multi-device pointers
 
## What this changes
 
Pointer motion was discarded whenever the device that pressed the button was
not the exact same device that produced the motion events.
 
That assumption does not hold on common hardware. On ThinkPads the physical
buttons belong to the TrackPoint device while motion comes from the Synaptics
touchpad, so press and motion never match and nothing is ever drawn:
 
```
BUTTON_PRESS device="TPPS/2 IBM TrackPoint"
MOTION       device="SynPS/2 Synaptics TouchPad"
MOTION       device="SynPS/2 Synaptics TouchPad"
BUTTON_RELEASE device="TPPS/2 IBM TrackPoint"
```
 
Multiple physical devices share a single pointer cursor, so they must all be
accepted. The check now only rejects devices that own a *separate* cursor
(touchscreen, pen, eraser, tablet), which is what the Wayland two-cursor guard
was actually meant to do.
 
Also adds `_getEventDevice()`, which centralises the existing
`get_source_device()` / `get_device()` version handling in one place.
 
If `Clutter.InputDeviceType` or `get_device_type()` is unavailable, the check
fails open and lets the event through, so it cannot break drawing on a GNOME
version where the API differs.
 
## Files changed
 
- `area.js`

## Tested on
 
- GNOME Shell 50.4, Fedora release 44 (Forty Four), Wayland — drawing with touchpad, trackpoint and USB mouse

## Known limitations
 
- Tested on GNOME 50 only; not verified on 46–49
- Not tested on X11, or with touchscreen/stylus hardware (the device types the
  check still filters out)


## Cut out of output came from a temporary debug handler (not included in this PR):

<details>
<summary>Log</summary>

DoG-DEBUG: BUTTON_PRESS device="TPPS/2 IBM TrackPoint"
DoG-DEBUG: MOTION device="SynPS/2 Synaptics TouchPad"
DoG-DEBUG: MOTION device="SynPS/2 Synaptics TouchPad"
...
DoG-DEBUG: MOTION device="SynPS/2 Synaptics TouchPad"
DoG-DEBUG: BUTTON_RELEASE device="TPPS/2 IBM TrackPoint"


</details>